### PR TITLE
[REL05-BP02] Implement API Gateway Stage-Level Request Throttling

### DIFF
--- a/python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py
+++ b/python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py
@@ -154,13 +154,15 @@ class ApigwHttpApiLambdaDynamodbPythonCdkStack(Stack):
         demo_table.grant_write_data(api_hanlder)
         api_hanlder.add_environment("TABLE_NAME", demo_table.table_name)
 
-        # Create API Gateway with X-Ray tracing enabled
+        # Create API Gateway with X-Ray tracing and throttling enabled (REL05-BP02)
         api = apigw_.LambdaRestApi(
             self,
             "Endpoint",
             handler=api_hanlder,
             deploy_options=apigw_.StageOptions(
-                tracing_enabled=True  # Enable X-Ray tracing
+                tracing_enabled=True,  # Enable X-Ray tracing
+                throttling_rate_limit=100,    # 100 requests per second
+                throttling_burst_limit=200    # 200 burst capacity
             )
         )
 


### PR DESCRIPTION
## **AWS Well-Architected Framework Compliance Fix**

**Best Practice**: REL05-BP02 Throttle requests  
**Risk Level**: HIGH → RESOLVED  
**Resolves**: #5

### **Changes Made**

✅ **Implemented stage-level API Gateway throttling**:
- Added `throttling_rate_limit=100` (100 requests per second)
- Added `throttling_burst_limit=200` (200 burst capacity)
- Updated `StageOptions` in `LambdaRestApi` configuration

### **Code Changes**

```python
# Before (vulnerable to traffic spikes)
deploy_options=apigw_.StageOptions(
    tracing_enabled=True
)

# After (REL05-BP02 compliant)
deploy_options=apigw_.StageOptions(
    tracing_enabled=True,
    throttling_rate_limit=100,    # 100 requests per second
    throttling_burst_limit=200    # 200 burst capacity
)
```

### **Compliance Benefits**

- ✅ **Prevents resource exhaustion** from unexpected traffic spikes
- ✅ **Mitigates DDoS attacks** and retry storms
- ✅ **Returns 429 Too Many Requests** when limits exceeded
- ✅ **Implements token bucket algorithm** as recommended by REL05-BP02
- ✅ **Maintains normal processing** under supported request volume

### **Testing Recommendations**

1. **Load test** the API to verify throttling behavior
2. **Monitor CloudWatch metrics**: `4XXError`, `Count`, `Latency`
3. **Verify 429 responses** when rate limits are exceeded
4. **Test burst capacity** handling during traffic spikes

### **Next Steps**

This PR addresses the **highest priority** REL05-BP02 compliance issue. Additional enhancements in separate PRs:
- Lambda reserved concurrency (#6)
- Usage plans with per-client throttling (#7)
- Optional WAF rate limiting (#8)

**Files Modified**:
- `stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py`