### PR TITLE
[REL05-BP02] Configure Lambda Reserved Concurrency for Resource Protection

### DIFF
--- a/python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py
+++ b/python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py
@@ -133,7 +133,7 @@ class ApigwHttpApiLambdaDynamodbPythonCdkStack(Stack):
             data_resource_values=[demo_table.table_arn]
         )
 
-        # Create the Lambda function to receive the request
+        # Create the Lambda function with reserved concurrency (REL05-BP02)
         api_hanlder = lambda_.Function(
             self,
             "ApiHandler",
@@ -148,6 +148,7 @@ class ApigwHttpApiLambdaDynamodbPythonCdkStack(Stack):
             memory_size=1024,
             timeout=Duration.minutes(5),
             tracing=lambda_.Tracing.ACTIVE,  # Enable X-Ray tracing
+            reserved_concurrent_executions=50  # Prevent account concurrency exhaustion
         )
 
         # grant permission to lambda to write to demo table


### PR DESCRIPTION
## **AWS Well-Architected Framework Compliance Fix**

**Best Practice**: REL05-BP02 Throttle requests  
**Risk Level**: MEDIUM → RESOLVED  
**Resolves**: #6

### **Changes Made**

✅ **Implemented Lambda reserved concurrency**:
- Added `reserved_concurrent_executions=50` to Lambda function
- Prevents account-level concurrency exhaustion during traffic spikes
- Protects other Lambda functions from resource starvation

### **Code Changes**

```python
# Before (vulnerable to concurrency exhaustion)
api_hanlder = lambda_.Function(
    self,
    "ApiHandler",
    # ... other configuration
    # Missing: reserved_concurrent_executions
)

# After (REL05-BP02 compliant)
api_hanlder = lambda_.Function(
    self,
    "ApiHandler",
    function_name="apigw_handler",
    runtime=lambda_.Runtime.PYTHON_3_9,
    code=lambda_.Code.from_asset("lambda/apigw-handler"),
    handler="index.handler",
    vpc=vpc,
    vpc_subnets=ec2.SubnetSelection(
        subnet_type=ec2.SubnetType.PRIVATE_ISOLATED
    ),
    memory_size=1024,
    timeout=Duration.minutes(5),
    tracing=lambda_.Tracing.ACTIVE,
    reserved_concurrent_executions=50  # Prevent account concurrency exhaustion
)
```

### **Compliance Benefits**

- ✅ **Prevents resource exhaustion** at the Lambda account level
- ✅ **Protects other functions** from being starved of concurrency
- ✅ **Limits blast radius** during traffic spikes
- ✅ **Enables predictable performance** under load
- ✅ **Aligns with DynamoDB capacity** planning

### **Testing Recommendations**

1. **Load test** to verify concurrency limiting behavior
2. **Monitor CloudWatch metrics**: `ConcurrentExecutions`, `Throttles`
3. **Test behavior** when concurrency limit is reached
4. **Verify other Lambda functions** remain unaffected during spikes

### **Implementation Notes**

- **Reserved concurrency: 50** - Balances performance with resource protection
- **Aligns with API Gateway throttling** for consistent request handling
- **Consider DynamoDB write capacity** when setting concurrency limits
- **Existing throttle alarm** will monitor reserved concurrency behavior

**Files Modified**:
- `stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py`