### PR TITLE
[REL05-BP02] Implement API Gateway Usage Plans with Per-Client Throttling

### DIFF
--- a/python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py
+++ b/python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py
@@ -164,6 +164,31 @@ class ApigwHttpApiLambdaDynamodbPythonCdkStack(Stack):
             )
         )
 
+        # Create usage plan with per-client throttling (REL05-BP02)
+        usage_plan = api.add_usage_plan(
+            "DefaultUsagePlan",
+            name="default-usage-plan",
+            description="Default usage plan with throttling limits",
+            throttle=apigw_.ThrottleSettings(
+                rate_limit=50,    # 50 requests per second per API key
+                burst_limit=100   # 100 burst capacity per API key
+            ),
+            quota=apigw_.QuotaSettings(
+                limit=10000,      # 10,000 requests per day
+                period=apigw_.Period.DAY
+            )
+        )
+
+        # Create API key for throttling control
+        api_key = api.add_api_key(
+            "DefaultApiKey",
+            api_key_name="default-api-key",
+            description="Default API key for throttling"
+        )
+
+        # Associate API key with usage plan
+        usage_plan.add_api_key(api_key)
+
         # CloudWatch Alarms for monitoring
         lambda_error_alarm = cloudwatch.Alarm(
             self,


### PR DESCRIPTION
## **AWS Well-Architected Framework Compliance Fix**

**Best Practice**: REL05-BP02 Throttle requests  
**Risk Level**: MEDIUM → RESOLVED  
**Resolves**: #7

### **Changes Made**

✅ **Implemented API Gateway usage plans with per-client throttling**:
- Added usage plan with `ThrottleSettings` (rate_limit: 50, burst_limit: 100)
- Added quota settings for daily request limits (10,000 requests/day)
- Created API key and associated with usage plan
- Provides per-client throttling control

### **Code Changes**

```python
# Added usage plan with per-client throttling (REL05-BP02)
usage_plan = api.add_usage_plan(
    "DefaultUsagePlan",
    name="default-usage-plan",
    description="Default usage plan with throttling limits",
    throttle=apigw_.ThrottleSettings(
        rate_limit=50,    # 50 requests per second per API key
        burst_limit=100   # 100 burst capacity per API key
    ),
    quota=apigw_.QuotaSettings(
        limit=10000,      # 10,000 requests per day
        period=apigw_.Period.DAY
    )
)

# Create API key for throttling control
api_key = api.add_api_key(
    "DefaultApiKey",
    api_key_name="default-api-key",
    description="Default API key for throttling"
)

# Associate API key with usage plan
usage_plan.add_api_key(api_key)
```

### **Compliance Benefits**

- ✅ **Per-client throttling** prevents individual consumers from exhausting resources
- ✅ **Defense in depth** when combined with stage-level throttling
- ✅ **Quota management** with daily request limits
- ✅ **API key management** for consumer identification
- ✅ **Granular control** over different consumer tiers

### **Usage Instructions**

1. **API consumers** must include the API key in requests via `x-api-key` header
2. **Rate limiting** applies per API key (50 rps, 100 burst)
3. **Daily quotas** reset at midnight UTC (10,000 requests/day)
4. **Multiple usage plans** can be created for different consumer tiers

### **Testing Recommendations**

1. **Test per-client throttling** with API key
2. **Monitor CloudWatch metrics**: `4XXError`, `Count` by API key
3. **Verify quota enforcement** at daily limits
4. **Test behavior** without API key (should be blocked if required)

### **Implementation Notes**

- **Usage plan throttling** is applied per API key
- **Combine with stage-level throttling** for comprehensive protection
- **Consider different usage plans** for different consumer tiers
- **API key requirement** can be enforced per method if needed

**Files Modified**:
- `stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py`